### PR TITLE
Fix an compiler error  

### DIFF
--- a/dep/skiplist.c
+++ b/dep/skiplist.c
@@ -18,6 +18,9 @@ static inline void rm_free(void *p) {
     RedisModule_Free(p);
 }
 
+RedisModuleString *shared_minstring = NULL;
+RedisModuleString *shared_maxstring = NULL;
+
 /* Create a skiplist node with the specified number of levels.
  * The SDS string 'ele' is referenced by the node after the call. */
 m_zskiplistNode *m_zslCreateNode(int level, scoretype *score, RedisModuleString *ele) {
@@ -735,7 +738,7 @@ fail:
 inline int mscoreCmp(scoretype *s1, scoretype *s2) {
     assert(s1 != NULL);
     assert(s2 != NULL);
-    assert(s1->score_num == s1->score_num);
+    assert(s1->score_num == s2->score_num);
 
     int num = s1->score_num, i;
 

--- a/dep/skiplist.h
+++ b/dep/skiplist.h
@@ -55,8 +55,8 @@ typedef struct {
     int minex, maxex;             /* are min or max exclusive? */
 } m_zlexrangespec;
 
-RedisModuleString *shared_minstring;
-RedisModuleString *shared_maxstring;
+extern RedisModuleString *shared_minstring;
+extern RedisModuleString *shared_maxstring;
 
 m_zskiplist *m_zslCreate(unsigned char score_num);
 void m_zslFree(m_zskiplist *zsl);


### PR DESCRIPTION
1. Fixed an compiler error caused by declaring non-static variables in header file and included by external .c files more than once~
2. Fix a typo in assert()

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/ld: CMakeFiles/tairzset_module.dir/__/dep/skiplist.c.o:/data/alibaba/TairZset/dep/skiplist.h:59: multiple definition of `shared_maxstring'; CMakeFiles/tairzset_module.dir/tairzset.c.o:/data/alibaba/TairZset/dep/skiplist.h:59: first defined here
/usr/bin/ld: CMakeFiles/tairzset_module.dir/__/dep/skiplist.c.o:/data/alibaba/TairZset/dep/skiplist.h:58: multiple definition of `shared_minstring'; CMakeFiles/tairzset_module.dir/tairzset.c.o:/data/alibaba/TairZset/dep/skiplist.h:58: first defined here
collect2: error: ld returned 1 exit status
