### PR TITLE
Feat: implement new command EXZMSCORE

### DIFF
--- a/CMDDOC.md
+++ b/CMDDOC.md
@@ -230,6 +230,18 @@ If member does not exist in the tairzset or key does not exist, Bulk string repl
 > EXZCOUNT key min max   
 > time complexity：O(log(N)) with N being the number of elements in the tairzset.
 
+### EXZMSCORE
+> EXZMSCORE key member [member ...]
+> time complexity：O(N) where N is the number of members being requested.
+
+#### Command Description:
+
+Returns the scores associated with the specified members in the sorted set stored at key. For every member that does not exist in the sorted set, a nil value is returned.
+
+#### Return value
+
+Array reply: list of scores or nil associated with the specified member values (multiple double-precision floating-point numbers separated by #), represented as strings.
+
 #### Command Description:
 Returns the number of elements in the tairzset at key with a score between min and max.
 

--- a/tests/tairzset.tcl
+++ b/tests/tairzset.tcl
@@ -814,6 +814,44 @@ start_server {tags {"tairzset"} overrides {bind 0.0.0.0}} {
         assert_error "*not*string*" {r exzrangebylex fooz +x \[bar}
         assert_error "*not*string*" {r exzrangebylex fooz -x \[bar}
     }
+
+    test "EXZMSCORE basic" {   
+        r del exzmscoretest
+        r exzadd exzmscoretest 10 x
+        r exzadd exzmscoretest 20 y
+
+        assert_equal {10 20} [r exzmscore exzmscoretest x y]
+    } 
+
+    test "EXZMSCORE retrieve from empty set" {
+        r del exzmscoretest
+
+        assert_equal {{} {}} [r exzmscore exzmscoretest x y]
+    } 
+
+    test "EXZMSCORE retrieve with missing member" {
+        r del exzmscoretest
+        r exzadd exzmscoretest 10 x
+
+        assert_equal {10 {}} [r exzmscore exzmscoretest x y]
+    } 
+
+    test "EXZMSCORE retrieve single member" {
+        r del exzmscoretest
+        r exzadd exzmscoretest 10 x
+        r exzadd exzmscoretest 20 y
+
+        assert_equal {10} [r exzmscore exzmscoretest x]
+    } 
+
+    test "EXZMSCORE retrieve requires one or more members" {
+        r del exzmscoretest
+        r zadd exzmscoretest 10 x
+        r zadd exzmscoretest 20 y
+
+        catch {r exzmscore exzmscoretest} e
+        assert_match {*ERR*wrong*number*arg*} $e
+    }
 }
 
 start_server {tags {"repl test"} overrides {bind 0.0.0.0}} {

--- a/tests/tairzset.tcl
+++ b/tests/tairzset.tcl
@@ -821,6 +821,12 @@ start_server {tags {"tairzset"} overrides {bind 0.0.0.0}} {
         r exzadd exzmscoretest 20 y
 
         assert_equal {10 20} [r exzmscore exzmscoretest x y]
+
+        r del exzmscoretest
+        r exzadd exzmscoretest 10#20 x
+        r exzadd exzmscoretest 20#30 y
+
+        assert_equal {10#20 20#30} [r exzmscore exzmscoretest x y]
     } 
 
     test "EXZMSCORE retrieve from empty set" {
@@ -834,6 +840,11 @@ start_server {tags {"tairzset"} overrides {bind 0.0.0.0}} {
         r exzadd exzmscoretest 10 x
 
         assert_equal {10 {}} [r exzmscore exzmscoretest x y]
+
+        r del exzmscoretest
+        r exzadd exzmscoretest 10#1.1 x
+
+        assert_equal {10#1.1000000000000001 {}} [r exzmscore exzmscoretest x y]
     } 
 
     test "EXZMSCORE retrieve single member" {
@@ -842,6 +853,14 @@ start_server {tags {"tairzset"} overrides {bind 0.0.0.0}} {
         r exzadd exzmscoretest 20 y
 
         assert_equal {10} [r exzmscore exzmscoretest x]
+        assert_equal {20} [r exzmscore exzmscoretest y]
+
+        r del exzmscoretest
+        r exzadd exzmscoretest 10#20#30#40 x
+        r exzadd exzmscoretest 20#10#50#60 y
+
+        assert_equal {10#20#30#40} [r exzmscore exzmscoretest x]
+        assert_equal {20#10#50#60} [r exzmscore exzmscoretest y]
     } 
 
     test "EXZMSCORE retrieve requires one or more members" {


### PR DESCRIPTION
Signed-off-by: RinChanNOWWW <hzy427@gmail.com>

# Summary

related issues: #4

### EXZMSCORE
> EXZMSCORE key member [member ...]
> time complexity：O(N) where N is the number of members being requested.
### Command Description:

Returns the scores associated with the specified members in the sorted set stored at key. For every member that does not exist in the sorted set, a nil value is returned.

### Return value

Array reply: list of scores or nil associated with the specified member values (a double precision floating point number), represented as strings.