### PR TITLE
Feat: implement new command EXZSCAN and fix compile warnings.

### DIFF
--- a/CMDDOC.md
+++ b/CMDDOC.md
@@ -283,3 +283,22 @@ The optional WITHSCORES modifier changes the reply so it includes the respective
 Bulk string reply: without the additional count argument, the command returns a Bulk Reply with the randomly selected element, or nil when key does not exist.
 
 Array reply: when the additional count argument is passed, the command returns an array of elements, or an empty array when key does not exist. If the WITHSCORES modifier is used, the reply is a list elements and their scores from the sorted set.
+### EXZSCAN
+> EXZSCAN key cursor [MATCH pattern] [COUNT count]
+> time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
+
+#### Command Description:
+
+Iterates elements of TairZset types and their associated scores.
+
+EXSCAN is a cursor based iterator. This means that at every call of the command, the server returns an updated cursor that the user needs to use as the cursor argument in the next call. An iteration starts when the cursor is set to 0, and terminates when the cursor returned by the server is 0. 
+
+While EXSCAN does not provide guarantees about the number of elements returned at every iteration, it is possible to empirically adjust the behavior of EXZSCAN using the COUNT option. Basically with COUNT the user specified the amount of work that should be done at every call in order to retrieve elements from the collection. This is *just a hint* for the implementation, however generally speaking this is what you could expect most of the times from the implementation.
+
+It is possible to only iterate elements matching a given glob-style pattern, similarly to the behavior of the KEYS command that takes a pattern as only argument. To do so, just append the MATCH <pattern> arguments at the end of the EXZSCAN command. It is important to note that the MATCH filter is applied after elements are retrieved from the collection, just before returning data to the client. This means that if the pattern matches very little elements inside the collection, EXZSCAN will likely return no elements in most iterations.
+
+More detail information: https://redis.io/commands/scan/
+
+#### Return value
+
+A two elements multi-bulk reply, where the first element is a string representing an unsigned 64 bit number (the cursor), and the second element is a multi-bulk with an array of elements.

--- a/dep/adlist.c
+++ b/dep/adlist.c
@@ -1,0 +1,382 @@
+/* adlist.c - A generic doubly linked list implementation
+ *
+ * Copyright (c) 2006-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <stdlib.h>
+#include "adlist.h"
+
+#define REDISMODULE_API_FUNC(x) (*x)
+extern void *REDISMODULE_API_FUNC(RedisModule_Alloc)(size_t bytes);
+extern void REDISMODULE_API_FUNC(RedisModule_Free)(void *ptr);
+
+#define zfree RedisModule_Free
+#define zmalloc RedisModule_Alloc
+
+/* Create a new list. The created list can be freed with
+ * AlFreeList(), but private value of every node need to be freed
+ * by the user before to call AlFreeList().
+ *
+ * On error, NULL is returned. Otherwise the pointer to the new list. */
+list *m_listCreate(void)
+{
+    struct list *list;
+
+    if ((list = zmalloc(sizeof(*list))) == NULL)
+        return NULL;
+    list->head = list->tail = NULL;
+    list->len = 0;
+    list->dup = NULL;
+    list->free = NULL;
+    list->match = NULL;
+    return list;
+}
+
+/* Remove all the elements from the list without destroying the list itself. */
+void m_listEmpty(list *list)
+{
+    unsigned long len;
+    listNode *current, *next;
+
+    current = list->head;
+    len = list->len;
+    while(len--) {
+        next = current->next;
+        if (list->free) list->free(current->value);
+        zfree(current);
+        current = next;
+    }
+    list->head = list->tail = NULL;
+    list->len = 0;
+}
+
+/* Free the whole list.
+ *
+ * This function can't fail. */
+void m_listRelease(list *list)
+{
+    m_listEmpty(list);
+    zfree(list);
+}
+
+/* Add a new node to the list, to head, containing the specified 'value'
+ * pointer as value.
+ *
+ * On error, NULL is returned and no operation is performed (i.e. the
+ * list remains unaltered).
+ * On success the 'list' pointer you pass to the function is returned. */
+list *m_listAddNodeHead(list *list, void *value)
+{
+    listNode *node;
+
+    if ((node = zmalloc(sizeof(*node))) == NULL)
+        return NULL;
+    node->value = value;
+    if (list->len == 0) {
+        list->head = list->tail = node;
+        node->prev = node->next = NULL;
+    } else {
+        node->prev = NULL;
+        node->next = list->head;
+        list->head->prev = node;
+        list->head = node;
+    }
+    list->len++;
+    return list;
+}
+
+/* Add a new node to the list, to tail, containing the specified 'value'
+ * pointer as value.
+ *
+ * On error, NULL is returned and no operation is performed (i.e. the
+ * list remains unaltered).
+ * On success the 'list' pointer you pass to the function is returned. */
+list *m_listAddNodeTail(list *list, void *value)
+{
+    listNode *node;
+
+    if ((node = zmalloc(sizeof(*node))) == NULL)
+        return NULL;
+    node->value = value;
+    if (list->len == 0) {
+        list->head = list->tail = node;
+        node->prev = node->next = NULL;
+    } else {
+        node->prev = list->tail;
+        node->next = NULL;
+        list->tail->next = node;
+        list->tail = node;
+    }
+    list->len++;
+    return list;
+}
+
+list *m_listInsertNode(list *list, listNode *old_node, void *value, int after) {
+    listNode *node;
+
+    if ((node = zmalloc(sizeof(*node))) == NULL)
+        return NULL;
+    node->value = value;
+    if (after) {
+        node->prev = old_node;
+        node->next = old_node->next;
+        if (list->tail == old_node) {
+            list->tail = node;
+        }
+    } else {
+        node->next = old_node;
+        node->prev = old_node->prev;
+        if (list->head == old_node) {
+            list->head = node;
+        }
+    }
+    if (node->prev != NULL) {
+        node->prev->next = node;
+    }
+    if (node->next != NULL) {
+        node->next->prev = node;
+    }
+    list->len++;
+    return list;
+}
+
+/* Remove the specified node from the specified list.
+ * It's up to the caller to free the private value of the node.
+ *
+ * This function can't fail. */
+void m_listDelNode(list *list, listNode *node)
+{
+    if (node->prev)
+        node->prev->next = node->next;
+    else
+        list->head = node->next;
+    if (node->next)
+        node->next->prev = node->prev;
+    else
+        list->tail = node->prev;
+    if (list->free) list->free(node->value);
+    zfree(node);
+    list->len--;
+}
+
+/* Returns a list iterator 'iter'. After the initialization every
+ * call to listNext() will return the next element of the list.
+ *
+ * This function can't fail. */
+listIter *m_listGetIterator(list *list, int direction)
+{
+    listIter *iter;
+
+    if ((iter = zmalloc(sizeof(*iter))) == NULL) return NULL;
+    if (direction == AL_START_HEAD)
+        iter->next = list->head;
+    else
+        iter->next = list->tail;
+    iter->direction = direction;
+    return iter;
+}
+
+/* Release the iterator memory */
+void m_listReleaseIterator(listIter *iter) {
+    zfree(iter);
+}
+
+/* Create an iterator in the list private iterator structure */
+void m_listRewind(list *list, listIter *li) {
+    li->next = list->head;
+    li->direction = AL_START_HEAD;
+}
+
+void m_listRewindTail(list *list, listIter *li) {
+    li->next = list->tail;
+    li->direction = AL_START_TAIL;
+}
+
+/* Return the next element of an iterator.
+ * It's valid to remove the currently returned element using
+ * listDelNode(), but not to remove other elements.
+ *
+ * The function returns a pointer to the next element of the list,
+ * or NULL if there are no more elements, so the classical usage patter
+ * is:
+ *
+ * iter = listGetIterator(list,<direction>);
+ * while ((node = listNext(iter)) != NULL) {
+ *     doSomethingWith(listNodeValue(node));
+ * }
+ *
+ * */
+listNode *m_listNext(listIter *iter)
+{
+    listNode *current = iter->next;
+
+    if (current != NULL) {
+        if (iter->direction == AL_START_HEAD)
+            iter->next = current->next;
+        else
+            iter->next = current->prev;
+    }
+    return current;
+}
+
+/* Duplicate the whole list. On out of memory NULL is returned.
+ * On success a copy of the original list is returned.
+ *
+ * The 'Dup' method set with listSetDupMethod() function is used
+ * to copy the node value. Otherwise the same pointer value of
+ * the original node is used as value of the copied node.
+ *
+ * The original list both on success or error is never modified. */
+list *m_listDup(list *orig)
+{
+    list *copy;
+    listIter iter;
+    listNode *node;
+
+    if ((copy = m_listCreate()) == NULL)
+        return NULL;
+    copy->dup = orig->dup;
+    copy->free = orig->free;
+    copy->match = orig->match;
+    m_listRewind(orig, &iter);
+    while((node = m_listNext(&iter)) != NULL) {
+        void *value;
+
+        if (copy->dup) {
+            value = copy->dup(node->value);
+            if (value == NULL) {
+                m_listRelease(copy);
+                return NULL;
+            }
+        } else
+            value = node->value;
+        if (m_listAddNodeTail(copy, value) == NULL) {
+            m_listRelease(copy);
+            return NULL;
+        }
+    }
+    return copy;
+}
+
+/* Search the list for a node matching a given key.
+ * The match is performed using the 'match' method
+ * set with listSetMatchMethod(). If no 'match' method
+ * is set, the 'value' pointer of every node is directly
+ * compared with the 'key' pointer.
+ *
+ * On success the first matching node pointer is returned
+ * (search starts from head). If no matching node exists
+ * NULL is returned. */
+listNode *m_listSearchKey(list *list, void *key)
+{
+    listIter iter;
+    listNode *node;
+
+    m_listRewind(list, &iter);
+    while((node = m_listNext(&iter)) != NULL) {
+        if (list->match) {
+            if (list->match(node->value, key)) {
+                return node;
+            }
+        } else {
+            if (key == node->value) {
+                return node;
+            }
+        }
+    }
+    return NULL;
+}
+
+/* Return the element at the specified zero-based index
+ * where 0 is the head, 1 is the element next to head
+ * and so on. Negative integers are used in order to count
+ * from the tail, -1 is the last element, -2 the penultimate
+ * and so on. If the index is out of range NULL is returned. */
+listNode *m_listIndex(list *list, long index) {
+    listNode *n;
+
+    if (index < 0) {
+        index = (-index)-1;
+        n = list->tail;
+        while(index-- && n) n = n->prev;
+    } else {
+        n = list->head;
+        while(index-- && n) n = n->next;
+    }
+    return n;
+}
+
+/* Rotate the list removing the tail node and inserting it to the head. */
+void m_listRotateTailToHead(list *list) {
+    if (listLength(list) <= 1) return;
+
+    /* Detach current tail */
+    listNode *tail = list->tail;
+    list->tail = tail->prev;
+    list->tail->next = NULL;
+    /* Move it as head */
+    list->head->prev = tail;
+    tail->prev = NULL;
+    tail->next = list->head;
+    list->head = tail;
+}
+
+/* Rotate the list removing the head node and inserting it to the tail. */
+void m_listRotateHeadToTail(list *list) {
+    if (listLength(list) <= 1) return;
+
+    listNode *head = list->head;
+    /* Detach current head */
+    list->head = head->next;
+    list->head->prev = NULL;
+    /* Move it as tail */
+    list->tail->next = head;
+    head->next = NULL;
+    head->prev = list->tail;
+    list->tail = head;
+}
+
+/* Add all the elements of the list 'o' at the end of the
+ * list 'l'. The list 'other' remains empty but otherwise valid. */
+void m_listJoin(list *l, list *o) {
+    if (o->head)
+        o->head->prev = l->tail;
+
+    if (l->tail)
+        l->tail->next = o->head;
+    else
+        l->head = o->head;
+
+    if (o->tail) l->tail = o->tail;
+    l->len += o->len;
+
+    /* Setup other as an empty list. */
+    o->head = o->tail = NULL;
+    o->len = 0;
+}

--- a/dep/adlist.h
+++ b/dep/adlist.h
@@ -1,0 +1,96 @@
+/* adlist.h - A generic doubly linked list implementation
+ *
+ * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ADLIST_H__
+#define __ADLIST_H__
+
+/* Node, List, and Iterator are the only data structures used currently. */
+
+typedef struct listNode {
+    struct listNode *prev;
+    struct listNode *next;
+    void *value;
+} listNode;
+
+typedef struct listIter {
+    listNode *next;
+    int direction;
+} listIter;
+
+typedef struct list {
+    listNode *head;
+    listNode *tail;
+    void *(*dup)(void *ptr);
+    void (*free)(void *ptr);
+    int (*match)(void *ptr, void *key);
+    unsigned long len;
+} list;
+
+/* Functions implemented as macros */
+#define listLength(l) ((l)->len)
+#define listFirst(l) ((l)->head)
+#define listLast(l) ((l)->tail)
+#define listPrevNode(n) ((n)->prev)
+#define listNextNode(n) ((n)->next)
+#define listNodeValue(n) ((n)->value)
+
+#define listSetDupMethod(l,m) ((l)->dup = (m))
+#define listSetFreeMethod(l,m) ((l)->free = (m))
+#define listSetMatchMethod(l,m) ((l)->match = (m))
+
+#define listGetDupMethod(l) ((l)->dup)
+#define listGetFree(l) ((l)->free)
+#define listGetMatchMethod(l) ((l)->match)
+
+/* Prototypes */
+list *m_listCreate(void);
+void m_listRelease(list *list);
+void m_listEmpty(list *list);
+list *m_listAddNodeHead(list *list, void *value);
+list *m_listAddNodeTail(list *list, void *value);
+list *m_listInsertNode(list *list, listNode *old_node, void *value, int after);
+void m_listDelNode(list *list, listNode *node);
+listIter *m_listGetIterator(list *list, int direction);
+listNode *m_listNext(listIter *iter);
+void m_listReleaseIterator(listIter *iter);
+list *m_listDup(list *orig);
+listNode *m_listSearchKey(list *list, void *key);
+listNode *m_listIndex(list *list, long index);
+void m_listRewind(list *list, listIter *li);
+void m_listRewindTail(list *list, listIter *li);
+void m_listRotateTailToHead(list *list);
+void m_listRotateHeadToTail(list *list);
+void m_listJoin(list *l, list *o);
+
+/* Directions for iterators */
+#define AL_START_HEAD 0
+#define AL_START_TAIL 1
+
+#endif /* __ADLIST_H__ */

--- a/dep/util.h
+++ b/dep/util.h
@@ -37,6 +37,7 @@
  * as a string (long double has a huge range).
  * This should be the size of the buffer given to ld2string */
 #define MAX_LONG_DOUBLE_CHARS 5*1024
+#define LONG_STR_SIZE      21          /* Bytes needed for long -> str + '\0' */
 
 #if __GNUC__ >= 4
 #define redis_unreachable __builtin_unreachable

--- a/src/tairzset.c
+++ b/src/tairzset.c
@@ -1070,7 +1070,7 @@ void exZscanGernericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     /* Step 4: Reply to the client. */
     RedisModule_ReplyWithArray(ctx, 2);
     char buf[LONG_STR_SIZE];
-    m_ll2string(buf,LONG_STR_SIZE,cursor);
+    m_ll2string(buf, LONG_STR_SIZE, cursor);
     RedisModule_ReplyWithCString(ctx, buf);
     RedisModule_ReplyWithArray(ctx, listLength(keys));
     while ((node = listFirst(keys)) != NULL) {
@@ -1089,7 +1089,6 @@ void exZscanGernericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
     }
 
 cleanup:
-    listSetFreeMethod(keys, NULL);
     m_listRelease(keys);
 }
 
@@ -1582,7 +1581,7 @@ int TairZsetTypeZscan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     cursor = strtoul(cursor_str, &eptr, 10);
     if (isspace(cursor_str[0]) || eptr[0] != '\0' || errno == ERANGE)
     {
-        RedisModule_ReplyWithError(ctx, "invalid cursor");
+        RedisModule_ReplyWithError(ctx, "ERR invalid cursor");
         return REDISMODULE_OK;
     }
 

--- a/src/tairzset.c
+++ b/src/tairzset.c
@@ -15,6 +15,7 @@
  */
 
 #include "tairzset.h"
+#include "adlist.h"
 
 #include <assert.h>
 #include <ctype.h>
@@ -572,7 +573,7 @@ static void exZaddGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
     }
 
     for (j = 0; j < elements; j++) {
-        scoretype *new_score;
+        scoretype *new_score = NULL;
         score = scores[j];
         int retflags = flags;
 
@@ -689,7 +690,6 @@ void exZrankGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
 #define ZRANGE_LEX 2
 void exZremrangeGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int rangetype) {
     TairZsetObj *zobj;
-    int keyremoved = 0;
     unsigned long deleted = 0;
     m_zrangespec range;
     m_zlexrangespec lexrange;
@@ -769,7 +769,6 @@ void exZremrangeGenericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
     }
     if (dictSize(zobj->dict) == 0) {
         RedisModule_DeleteKey(key);
-        keyremoved = 1;
     }
 
     RedisModule_ReplicateVerbatim(ctx);
@@ -960,6 +959,138 @@ void exZrandMemberWithCountCommand(RedisModuleCtx *ctx, TairZsetObj *zobj, long 
         /* Release memory */
         m_dictRelease(d);
     }
+}
+
+/* This callback is used by exZscanGernericCommand in order to collect elements
+ * returned by the dictionary iterator into a list. */
+void dictScanCallback(void *privdata, const m_dictEntry *de) {
+    void **pd = (void**) privdata;
+    list *keys = pd[0];
+    RedisModuleString *key = dictGetKey(de);;
+    scoretype *val = dictGetVal(de);
+
+    m_listAddNodeTail(keys, key);
+    if (val) m_listAddNodeTail(keys, val);
+}
+
+/* This command implements EXZSCAN commands.
+ *
+ * It returns both the members and scores of the scanned tair zset elements. */
+void exZscanGernericCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, TairZsetObj *zobj, unsigned long cursor) {
+    /* Set i to the first option argument. The previous one is cursor. */
+    int i = 3, j;
+    list *keys = m_listCreate();
+    listNode *node, *nextnode;
+    long long count = 10;
+    const char *pat = NULL;
+    size_t patlen;
+    int use_pattern = 0;
+    dict *ht;
+
+    while (i < argc) {
+        j = argc - i;
+        if (!mstringcasecmp(argv[i], "count") && j >= 2) {
+            if (RedisModule_StringToLongLong(argv[i+1], &count) != REDISMODULE_OK) {
+                RedisModule_ReplyWithError(ctx, "ERR value is not an integer or out of range");
+                goto cleanup;
+            }
+
+            if (count < 1) {
+                RedisModule_ReplyWithError(ctx, "ERR syntax error");
+                goto cleanup;
+            }
+
+            i += 2;
+        } else if (!mstringcasecmp(argv[i], "match") && j >= 2) {
+            pat = RedisModule_StringPtrLen(argv[i+1], &patlen);
+
+            /* The pattern always matches if it is exactly "*", so it is
+             * equivalent to disabling it. */
+            use_pattern = !(pat[0] == '*' && patlen == 1);
+
+            i += 2;
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR syntax error");
+            goto cleanup;
+        }
+    }
+
+    /* Step 2: Iterate the collection. */
+    ht = zobj->dict;
+    count *= 2;
+
+    void *privdata[1];
+    /* We set the max number of iterations to ten times the specified
+     * COUNT, so if the hash table is in a pathological state (very
+     * sparsely populated) we avoid to block too much time at the cost
+     * of returning no or very few elements. */
+    long maxiterations = count*10;
+
+    /* We pass two pointers to the callback: the list to which it will
+     * add new elements, and the object containing the dictionary so that
+     * it is possible to fetch more data in a type-dependent way. */
+    privdata[0] = keys;
+    do {
+        cursor = m_dictScan(ht, cursor, dictScanCallback, NULL, privdata);
+    } while (cursor &&
+            maxiterations-- &&
+            listLength(keys) < (unsigned long)count);
+
+    /* Step 3: Filter elements. */
+    node = listFirst(keys);
+    while (node) {
+        RedisModuleString *member = listNodeValue(node);
+        nextnode = listNextNode(node);
+        int filter = 0;
+        size_t member_str_len;
+        const char * member_str = RedisModule_StringPtrLen(member, &member_str_len);
+        
+        /* Filter element if it does not match the pattern. */
+        if (!filter && 
+            use_pattern && 
+            !m_stringmatchlen(pat, patlen, member_str, member_str_len, 0)) {
+            filter = 1; 
+        }
+
+        /* Remove the element and its associted value if needed. */
+        if (filter) {
+            /* Remove both member and score */
+            m_listDelNode(keys, node);
+            node = nextnode;
+            nextnode = listNextNode(node);
+            m_listDelNode(keys, node);
+        } else {
+            /* skip the score node associated with the member node */
+            node = nextnode;
+            nextnode = listNextNode(node);
+        }
+        node = nextnode;
+    }
+
+    /* Step 4: Reply to the client. */
+    RedisModule_ReplyWithArray(ctx, 2);
+    char buf[LONG_STR_SIZE];
+    m_ll2string(buf,LONG_STR_SIZE,cursor);
+    RedisModule_ReplyWithCString(ctx, buf);
+    RedisModule_ReplyWithArray(ctx, listLength(keys));
+    while ((node = listFirst(keys)) != NULL) {
+        /* member */
+        RedisModuleString *member = listNodeValue(node);
+        RedisModule_ReplyWithString(ctx, member);
+        m_listDelNode(keys, node);
+
+        /* score */
+        node = listFirst(keys);
+        scoretype *score = listNodeValue(node);
+        sds score_str = mscore2String(score);
+        RedisModule_ReplyWithStringBuffer(ctx, score_str, sdslen(score_str));
+        m_sdsfree(score_str);
+        m_listDelNode(keys, node);
+    }
+
+cleanup:
+    listSetFreeMethod(keys, NULL);
+    m_listRelease(keys);
 }
 
 /* ========================= "tairzset" type commands =======================*/
@@ -1381,7 +1512,7 @@ int TairZsetTypeZmscore_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **ar
     return REDISMODULE_OK;
 }
 
-/* EXZRANDMEMBER key [ count [WITHSCORES]] */
+/* EXZRANDMEMBER key [count [WITHSCORES]] */
 int TairZsetTypeZrandmember_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
     if (argc < 2) {
@@ -1432,6 +1563,51 @@ int TairZsetTypeZrandmember_RedisCommand(RedisModuleCtx *ctx, RedisModuleString 
     RedisModule_ReplyWithString(ctx, ele);
     return REDISMODULE_OK;
 }
+
+/* EXZSCAN key cursor [MATCH pattern] [COUNT count] */
+int TairZsetTypeZscan_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc < 3) {
+        return RedisModule_WrongArity(ctx);
+    }    
+    /* We need an *unsigned* long, 
+     * and RedisModule_StringToLongLong() does not cover the whole cursor space. 
+     * So we use RedisModule_StringPtrLen() to get the cursor string first,
+     * and use strtoul() to get the unsigned long cursor */
+    size_t cursor_str_len;
+    unsigned long cursor;
+    const char *cursor_str = RedisModule_StringPtrLen(argv[2], &cursor_str_len);
+    errno = 0;
+    char *eptr;
+    cursor = strtoul(cursor_str, &eptr, 10);
+    if (isspace(cursor_str[0]) || eptr[0] != '\0' || errno == ERANGE)
+    {
+        RedisModule_ReplyWithError(ctx, "invalid cursor");
+        return REDISMODULE_OK;
+    }
+
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    int type = RedisModule_KeyType(key);
+    if (REDISMODULE_KEYTYPE_EMPTY != type && RedisModule_ModuleTypeGetType(key) != TairZsetType) {
+        RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        return REDISMODULE_ERR;
+    }
+
+    TairZsetObj *tair_zset_obj = NULL;
+    if (type == REDISMODULE_KEYTYPE_EMPTY) {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithCString(ctx, "0");
+        RedisModule_ReplyWithArray(ctx, 0);
+        return REDISMODULE_OK;
+    } else {
+        tair_zset_obj = RedisModule_ModuleTypeGetValue(key);
+    }
+
+    exZscanGernericCommand(ctx, argv, argc, tair_zset_obj, cursor);
+
+    return REDISMODULE_OK;
+}
+
 
 /* ========================== "exstrtype" type methods =======================*/
 void *TairZsetTypeRdbLoad(RedisModuleIO *rdb, int encver) {
@@ -1614,6 +1790,7 @@ int Module_CreateCommands(RedisModuleCtx *ctx) {
     CREATE_ROCMD("exzlexcount", TairZsetTypeZlexcount_RedisCommand)
     CREATE_ROCMD("exzmscore", TairZsetTypeZmscore_RedisCommand)
     CREATE_ROCMD("exzrandmember", TairZsetTypeZrandmember_RedisCommand)
+    CREATE_ROCMD("exzscan", TairZsetTypeZscan_RedisCommand)
 
     return REDISMODULE_OK;
 }


### PR DESCRIPTION
Signed-off-by: RinChanNOWWW <hzy427@gmail.com>

# Summary

related issues: https://github.com/alibaba/TairZset/issues/4

Implementation reference: Redis 5.0 https://redis.io/commands/scan/

## Command Description 

### EXZSCAN
> EXZSCAN key cursor [MATCH pattern] [COUNT count]
> time complexity: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.

#### Command Description:

Iterates elements of TairZset types and their associated scores.

EXSCAN is a cursor based iterator. This means that at every call of the command, the server returns an updated cursor that the user needs to use as the cursor argument in the next call. An iteration starts when the cursor is set to 0, and terminates when the cursor returned by the server is 0. 

While EXSCAN does not provide guarantees about the number of elements returned at every iteration, it is possible to empirically adjust the behavior of EXZSCAN using the COUNT option. Basically with COUNT the user specified the amount of work that should be done at every call in order to retrieve elements from the collection. This is *just a hint* for the implementation, however generally speaking this is what you could expect most of the times from the implementation.

It is possible to only iterate elements matching a given glob-style pattern, similarly to the behavior of the KEYS command that takes a pattern as only argument. To do so, just append the MATCH <pattern> arguments at the end of the EXZSCAN command. It is important to note that the MATCH filter is applied after elements are retrieved from the collection, just before returning data to the client. This means that if the pattern matches very little elements inside the collection, EXZSCAN will likely return no elements in most iterations.

More detail information: https://redis.io/commands/scan/

#### Return value

A two elements multi-bulk reply, where the first element is a string representing an unsigned 64 bit number (the cursor), and the second element is a multi-bulk with an array of elements.

## Others

- Fix the compile warnings.
- Add a new data structure `list` (double linked list) from Redis source codes.
